### PR TITLE
Add blog homepage and first post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/tailwind": "^5.1.0",
+        "@tailwindcss/typography": "^0.5.19",
         "astro": "^4.16.0",
         "tailwindcss": "^3.4.0"
       },
@@ -1712,6 +1713,31 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@astrojs/tailwind": "^5.1.0",
+    "@tailwindcss/typography": "^0.5.19",
     "astro": "^4.16.0",
     "tailwindcss": "^3.4.0"
   },

--- a/src/content/blog/env-file-security-scanner.md
+++ b/src/content/blog/env-file-security-scanner.md
@@ -1,0 +1,187 @@
+---
+title: "Your .env File Is a Ticking Time Bomb — So We Built a Scanner in Half a Day"
+description: "How we used AI to build a client-side .env security scanner that detects 50+ API key patterns without your secrets ever leaving the browser."
+date: 2025-02-13
+tags: [security, dotenv, tools, ai]
+---
+
+*How we used AI to build a client-side .env security scanner that detects 50+ API key patterns without your secrets ever leaving the browser.*
+
+---
+
+We've all done it.
+
+You're moving fast, shipping features, juggling three services and a database. You toss your Stripe key into `.env`, your AWS credentials right below it, maybe a database URL with the password inline. You `.gitignore` it (hopefully) and move on with your life.
+
+Here's the thing: **your `.env` file is probably the most dangerous file in your entire project.** And almost nobody treats it that way.
+
+So we built a tool to fix that. In about half a day. With a lot of help from AI. Let us tell you how.
+
+## The Problem Nobody Talks About
+
+Every developer knows you shouldn't commit secrets to git. That's table stakes. But `.env` file security goes way beyond "did I add it to `.gitignore`?"
+
+Here's what actually goes wrong:
+
+- **Leaked API keys** — GitHub's secret scanning catches some patterns, but only after you've already pushed. By then, bots have already scraped it. AWS keys get compromised in [under a minute](https://www.comparitech.com/blog/information-security/github-honeypot-experiment/).
+- **Overly permissive keys** — That Stripe key in your `.env`? Is it the test key or the live one? Are you sure?
+- **No validation** — Your `.env` file has no schema, no types, no validation. It's just raw text. A missing quote, a trailing space, a duplicated key — any of these can silently break your app or, worse, expose data.
+- **Shared `.env` files** — Teams pass these around over Slack, email, sticky notes. Each copy is an untracked liability.
+- **Docker and CI leaks** — Environment variables get baked into images, logged in CI output, cached in build artifacts. The `.env` file is just the beginning.
+
+The dotenv security problem isn't a single vulnerability — it's a pattern of casual handling that compounds over time.
+
+## What We Built
+
+**[Halfday .env Validator & Security Scanner](https://halfday.dev/tools/env-validator)** — a free, browser-based tool that:
+
+- 🔍 **Detects 50+ API key patterns** — AWS, Stripe, GitHub, Slack, Twilio, SendGrid, OpenAI, and dozens more
+- ✅ **Validates .env syntax** — catches duplicates, malformed lines, missing values, and formatting issues
+- 🔒 **Runs entirely client-side** — your secrets never leave your browser. Zero server calls. Zero logging. Zero trust required.
+- 📊 **Gives you a security score** — a quick at-a-glance rating so you know how worried to be
+- 💡 **Actionable recommendations** — not just "you have a problem" but "here's what to do about it"
+
+Paste your `.env` file in, get instant feedback. That's it.
+
+## How We Built It (The Half-Day Sprint)
+
+This is a [Halfday](https://halfday.dev) project, which means two things: we build useful dev tools, and we build them fast — often with heavy AI assistance. This one came together in a single focused session.
+
+### The Stack
+
+Nothing fancy. Intentionally.
+
+- **Frontend:** HTML, CSS, vanilla JavaScript (or your lightweight framework of choice)
+- **Pattern matching:** Regular expressions — lots of them
+- **Deployment:** Static site — no backend needed, no backend wanted
+- **AI assist:** Claude for pattern generation, edge case discovery, and copy
+
+We deliberately avoided a backend. The whole point is that your `.env` contents should never touch a server. A static site means we can make that promise and you can verify it — just open DevTools and watch the network tab. Nothing leaves.
+
+### The Regex Engine
+
+The core of the tool is a pattern-matching engine. Each "detector" is essentially:
+
+```javascript
+{
+  name: "AWS Access Key ID",
+  pattern: /AKIA[0-9A-Z]{16}/,
+  severity: "critical",
+  description: "AWS access keys grant programmatic access to AWS services",
+  recommendation: "Rotate this key immediately via AWS IAM console"
+}
+```
+
+Simple? Yes. Effective? Extremely. Most API keys follow predictable formats — specific prefixes, fixed lengths, known character sets. A well-crafted regex catches them reliably.
+
+We also built detectors for structural issues:
+
+- Duplicate variable names (last one wins, but did you mean that?)
+- Lines missing `=` signs
+- Unquoted values with spaces
+- Empty values that might be placeholders
+- Variables that look like they contain URLs with embedded credentials
+
+## 50+ Patterns, and How AI Helped Generate Them
+
+Here's where it got interesting.
+
+We started with the obvious ones — AWS, Stripe, GitHub tokens. Patterns we'd seen a hundred times. But we wanted comprehensive coverage, and manually researching the key format for every SaaS API is... tedious.
+
+So we asked Claude to help. And this is where AI-assisted development genuinely shines — not writing the core logic, but **accelerating the boring-but-important research**.
+
+We prompted for:
+
+- Known API key formats with their regex patterns
+- Common prefixes (like `sk_live_`, `ghp_`, `xoxb-`)
+- Key length constraints and character sets
+- Which services use which patterns
+
+Then we verified each one against real documentation. AI got us to 80% in minutes instead of hours. The remaining 20% was manual verification, edge case handling, and testing against actual key formats.
+
+Here's a sample of what we detect:
+
+| Service | Pattern | Severity |
+|---------|---------|----------|
+| AWS Access Key | `AKIA` + 16 chars | 🔴 Critical |
+| Stripe Live Key | `sk_live_` prefix | 🔴 Critical |
+| GitHub PAT | `ghp_` + 36 chars | 🟡 High |
+| Slack Bot Token | `xoxb-` prefix | 🟡 High |
+| OpenAI API Key | `sk-` + 48 chars | 🟡 High |
+| SendGrid | `SG.` + base64 | 🟡 High |
+| Twilio | 32-char hex | 🟠 Medium |
+| Generic high-entropy | Shannon entropy check | 🟠 Medium |
+
+The full list covers 50+ services and patterns, including Mailgun, Firebase, Heroku, DigitalOcean, Shopify, Discord, and more.
+
+**The lesson:** AI is incredible at this kind of structured research task. It's not writing your app for you — it's compressing hours of documentation trawling into minutes of iterative prompting. That's the Halfday philosophy: use AI to build faster without sacrificing quality.
+
+## The Privacy-First Architecture
+
+Let's talk about the elephant in the room: **why would you paste your secrets into a web tool?**
+
+You shouldn't. Not into most of them. And that's exactly why we built this differently.
+
+The Halfday .env scanner is a **fully static, client-side application.** Here's what that means:
+
+1. **No server-side processing** — The page loads, and everything runs in your browser's JavaScript engine
+2. **No API calls** — Open your browser's Network tab. Paste your `.env`. Watch nothing happen. Zero requests.
+3. **No analytics on content** — We don't track what you paste, what keys are found, or what your variables are named
+4. **No storage** — Nothing goes to localStorage, sessionStorage, cookies, or IndexedDB
+5. **Fully auditable** — The source is right there in your browser. View source. Read it. We dare you.
+
+**Your secrets never leave your browser.** Period.
+
+We could have built a fancier tool with server-side analysis, AI-powered recommendations, historical tracking. But every one of those features requires sending your secrets somewhere. And a security tool that asks for your secrets is an oxymoron.
+
+## Things We Learned Building This
+
+A few surprises from the half-day sprint:
+
+**1. Key formats are wildly inconsistent.** Some services use clean prefixes (`sk_live_`). Others use generic hex strings. Some have moved through multiple formats over the years. Stripe alone has at least three key formats depending on when the key was generated.
+
+**2. False positives are a real design challenge.** A 32-character hex string could be a Twilio Auth Token, a random hash, or your cat's name encoded in hex. We tuned severity levels and descriptions to account for ambiguity rather than pretending everything is definitive.
+
+**3. Entropy detection is surprisingly useful.** Beyond specific patterns, we added Shannon entropy analysis. High-entropy strings (lots of randomness) in values are worth flagging even if they don't match a known pattern. If your `DATABASE_PASSWORD` has 4.5 bits of entropy per character, it's probably an actual secret, and you should know it's there.
+
+**4. .env syntax is "standards-optional."** There's no formal spec for `.env` files. Different parsers handle quotes, spaces, comments, and multiline values differently. We had to make opinionated choices about what counts as "valid" — and document those choices.
+
+## Try It — Seriously, Right Now
+
+Here's our pitch: **you have a `.env` file open in another tab right now.** (Don't lie, we know you do.)
+
+Go to **[halfday.dev/tools/env-validator](https://halfday.dev/tools/env-validator)**, paste it in, and see what comes back. It takes 10 seconds. Your secrets stay in your browser. And you might be surprised what's lurking in there.
+
+We've already caught:
+
+- Live Stripe keys in "development" `.env` files
+- AWS keys that were copy-pasted from production
+- Database URLs with plaintext passwords for services that support token auth
+- Duplicate variables where the "wrong" one was silently winning
+
+## What's Next
+
+This is a Halfday project, which means we ship fast, iterate in public, and move on to the next thing. But we've got ideas for this one:
+
+- **VS Code extension** — Scan on save, right in your editor
+- **CLI tool** — `npx halfday-env-scan` for CI pipeline integration
+- **Team patterns** — Define custom patterns for your org's internal services
+- **Pre-commit hook** — Catch issues before they hit version control
+
+Want to see any of these happen? **Tell us.** We build what developers actually want.
+
+---
+
+## Follow the Build-in-Public Journey
+
+Halfday is where we build useful dev tools with AI and write about the process — honestly, including the mistakes. Every tool, every sprint, every "how did we not think of that" moment.
+
+- 🌐 **[halfday.dev](https://halfday.dev)** — Try the .env scanner
+- ⭐ **Star us on GitHub** — Help other developers find these tools
+- 📧 **[hello@halfday.dev](mailto:hello@halfday.dev)** — Get in touch
+
+We build in half a day. You benefit for a lot longer.
+
+---
+
+*Have feedback on the .env scanner? Found a key pattern we're missing? [Let us know](mailto:hello@halfday.dev) — we ship fixes fast.*

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.date(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 interface Props { title: string; description?: string; }
-const { title, description = '.env file validator and security scanner. Detect leaked API keys, weak passwords, and misconfigurations. 100% client-side.' } = Astro.props;
+const { title, description = 'Halfday — tools built in half a day. Developer tools, build logs, and the stories behind them.' } = Astro.props;
+const currentPath = Astro.url.pathname;
 ---
 <!doctype html>
 <html lang="en" class="dark">
@@ -11,14 +12,44 @@ const { title, description = '.env file validator and security scanner. Detect l
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://halfday.dev/tools/env-validator" />
+  <meta property="og:url" content="https://halfday.dev" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>{title}</title>
 </head>
-<body class="bg-gray-950 text-gray-100 min-h-screen flex flex-col antialiased">
-  <slot />
+<body class="bg-[#0a0a0a] text-gray-100 min-h-screen flex flex-col antialiased">
+  <!-- Nav -->
+  <header class="border-b border-white/[0.06] px-4 py-4">
+    <div class="max-w-3xl mx-auto flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2.5 group">
+        <div class="w-8 h-8 rounded-lg bg-emerald-500 flex items-center justify-center font-bold text-white text-sm">H</div>
+        <div>
+          <span class="font-semibold text-lg">Halfday</span>
+          <span class="text-gray-500 text-xs ml-2 hidden sm:inline">tools built in half a day</span>
+        </div>
+      </a>
+      <nav class="flex items-center gap-6 text-sm">
+        <a href="/" class:list={["transition hover:text-emerald-400", currentPath === '/' ? 'text-emerald-400' : 'text-gray-400']}>Blog</a>
+        <a href="/tools" class:list={["transition hover:text-emerald-400", currentPath.startsWith('/tools') ? 'text-emerald-400' : 'text-gray-400']}>Tools</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="flex-1 px-4 py-12">
+    <slot />
+  </main>
+
+  <!-- Footer -->
+  <footer class="border-t border-white/[0.06] px-4 py-8 mt-auto">
+    <div class="max-w-3xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-gray-500">
+      <span>&copy; {new Date().getFullYear()} Halfday</span>
+      <div class="flex items-center gap-5">
+        <a href="https://github.com/halfday-dev" class="hover:text-gray-300 transition">GitHub</a>
+        <a href="mailto:hello@halfday.dev" class="hover:text-gray-300 transition">hello@halfday.dev</a>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,0 +1,53 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+<Layout title={`${post.data.title} — Halfday`} description={post.data.description}>
+  <article class="max-w-3xl mx-auto">
+    <header class="mb-10">
+      <a href="/" class="text-sm text-gray-500 hover:text-emerald-400 transition mb-4 inline-block">← Back to blog</a>
+      <h1 class="text-3xl sm:text-4xl font-bold tracking-tight leading-tight mb-3">{post.data.title}</h1>
+      <div class="flex items-center gap-4 text-sm text-gray-500">
+        <time datetime={post.data.date.toISOString().slice(0, 10)}>
+          {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+        </time>
+        {post.data.tags.length > 0 && (
+          <div class="flex gap-2">
+            {post.data.tags.map((tag: string) => (
+              <span class="text-gray-600">#{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </header>
+    <div class="prose prose-invert prose-emerald max-w-none
+      prose-headings:font-semibold prose-headings:tracking-tight
+      prose-h2:text-2xl prose-h2:mt-12 prose-h2:mb-4
+      prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-3
+      prose-p:text-gray-300 prose-p:leading-relaxed
+      prose-a:text-emerald-400 prose-a:no-underline hover:prose-a:text-emerald-300
+      prose-strong:text-gray-100
+      prose-li:text-gray-300
+      prose-code:text-emerald-400 prose-code:bg-white/[0.06] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+      prose-pre:bg-white/[0.04] prose-pre:border prose-pre:border-white/[0.06]
+      prose-table:text-sm
+      prose-th:text-gray-300 prose-th:border-white/10
+      prose-td:border-white/[0.06]
+      prose-hr:border-white/[0.06]
+      prose-blockquote:border-emerald-500/50 prose-blockquote:text-gray-400
+    ">
+      <Content />
+    </div>
+  </article>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,30 @@
 ---
-return Astro.redirect('/tools/env-validator');
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
+<Layout title="Halfday — tools built in half a day">
+  <div class="max-w-3xl mx-auto">
+    <div class="mb-12">
+      <h1 class="text-4xl font-bold tracking-tight mb-3">Halfday</h1>
+      <p class="text-gray-400 text-lg">We build useful developer tools — fast, with AI, and write about it honestly.</p>
+    </div>
+
+    <div class="space-y-10">
+      {posts.map((post) => (
+        <article>
+          <time class="text-sm text-gray-500 tabular-nums" datetime={post.data.date.toISOString().slice(0, 10)}>
+            {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+          </time>
+          <h2 class="text-xl font-semibold mt-1 mb-2">
+            <a href={`/blog/${post.slug}`} class="hover:text-emerald-400 transition">{post.data.title}</a>
+          </h2>
+          <p class="text-gray-400 leading-relaxed">{post.data.description}</p>
+          <a href={`/blog/${post.slug}`} class="inline-block mt-3 text-sm text-emerald-400 hover:text-emerald-300 transition">Read more →</a>
+        </article>
+      ))}
+    </div>
+  </div>
+</Layout>

--- a/src/pages/tools/env-validator.astro
+++ b/src/pages/tools/env-validator.astro
@@ -2,21 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 ---
 <Layout title="ENV Validator & Security Scanner — Halfday">
-  <!-- Header -->
-  <header class="border-b border-gray-800 px-4 py-4">
-    <div class="max-w-5xl mx-auto flex items-center justify-between">
-      <a href="https://halfday.dev" class="flex items-center gap-2">
-        <div class="w-8 h-8 rounded-lg bg-emerald-500 flex items-center justify-center font-bold text-white text-sm">H</div>
-        <div>
-          <span class="font-semibold text-lg">Halfday</span>
-          <span class="text-gray-500 text-xs ml-2 hidden sm:inline">tools built in half a day</span>
-        </div>
-      </a>
-      <a href="https://halfday.dev/tools" class="text-sm text-gray-400 hover:text-emerald-400 transition">← All Tools</a>
-    </div>
-  </header>
-
-  <main class="flex-1 px-4 py-8 max-w-5xl mx-auto w-full">
+  <div class="max-w-5xl mx-auto w-full">
     <!-- Trust Banner -->
     <div class="mb-6 flex items-center gap-2 bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-4 py-3 text-emerald-400 text-sm">
       <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
@@ -74,12 +60,7 @@ import Layout from '../../layouts/Layout.astro';
         <pre id="gitignoreSuggest" class="bg-gray-900 border border-gray-800 rounded-lg p-4 font-mono text-sm text-gray-300 overflow-x-auto"></pre>
       </div>
     </div>
-  </main>
-
-  <!-- Footer -->
-  <footer class="border-t border-gray-800 px-4 py-6 text-center text-gray-500 text-sm">
-    <p>Built by <a href="https://halfday.dev" class="text-emerald-400 hover:underline">Halfday</a> · <a href="https://github.com/halfday-dev" class="text-gray-400 hover:text-emerald-400 transition">GitHub</a></p>
-  </footer>
+  </div>
 
   <script>
     import { patterns, weakPasswords, analyze, computeScore } from '../../lib/scanner.js';

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -1,0 +1,26 @@
+---
+import Layout from '../../layouts/Layout.astro';
+
+const tools = [
+  {
+    name: '.env Validator & Security Scanner',
+    description: 'Detect leaked API keys, weak passwords, and misconfigurations in your .env files. 100% client-side — your secrets never leave your browser.',
+    href: '/tools/env-validator',
+  },
+];
+---
+<Layout title="Tools — Halfday">
+  <div class="max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold tracking-tight mb-3">Tools</h1>
+    <p class="text-gray-400 mb-10">Free developer tools, built fast. All client-side, all open source.</p>
+
+    <div class="space-y-4">
+      {tools.map((tool) => (
+        <a href={tool.href} class="block p-6 rounded-xl border border-white/[0.06] hover:border-emerald-500/30 bg-white/[0.02] hover:bg-white/[0.04] transition group">
+          <h2 class="text-lg font-semibold group-hover:text-emerald-400 transition">{tool.name}</h2>
+          <p class="text-gray-400 text-sm mt-1.5 leading-relaxed">{tool.description}</p>
+        </a>
+      ))}
+    </div>
+  </div>
+</Layout>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,5 +3,5 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   darkMode: 'class',
   theme: { extend: {} },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 };


### PR DESCRIPTION
Transforms halfday.dev from a single-tool redirect into a blog-first site with tools.

## What changed
- **Blog infrastructure** — Astro Content Collections with frontmatter schema (title, description, date, tags, draft)
- **First blog post** — "Your .env File Is a Ticking Time Bomb" build story
- **Homepage** — Blog-first layout showing recent posts with Halfday branding
- **Tools index** — `/tools` page listing available tools
- **Shared layout** — Consistent nav (Blog, Tools) and footer across all pages
- **Typography** — `@tailwindcss/typography` with prose-invert for blog posts
- **Dark theme** — #0a0a0a bg, emerald accents, clean minimal aesthetic

## Pages
- `/` — Blog homepage
- `/blog/env-file-security-scanner` — First post
- `/tools` — Tools index
- `/tools/env-validator` — Existing tool (now with shared nav/footer)

Build passes ✅ | Tests pass ✅ (60/60)